### PR TITLE
Fix event timeline assignment

### DIFF
--- a/InstrumentsProcessor/Parsing/TraceSourceParser.cs
+++ b/InstrumentsProcessor/Parsing/TraceSourceParser.cs
@@ -64,19 +64,24 @@ namespace InstrumentsProcessor.Parsing
         {
             Timestamp? firstEventTimestamp = null;
             Timestamp? lastEventTimestamp = null;
+            DateTime? recordingStartUtc = null;
 
             foreach (IDataSource dataSource in dataSources)
             {
-                ProcessDataSource(dataSource, ref firstEventTimestamp, ref lastEventTimestamp, dataProcessor, progress, cancellationToken);
+                ProcessDataSource(dataSource, ref firstEventTimestamp, ref lastEventTimestamp, ref recordingStartUtc, dataProcessor, progress, cancellationToken);
             }
 
             long firstEventTimestampNanoseconds = firstEventTimestamp.HasValue ? firstEventTimestamp.Value.ToNanoseconds : 0;
             long lastEventTimestampnanoseconds = lastEventTimestamp.HasValue ? lastEventTimestamp.Value.ToNanoseconds : firstEventTimestampNanoseconds + 1;
-            DateTime firstEventWallClockUtc = DateTime.UtcNow;
+
+            // Anchor the trace's wall-clock to the recording's actual start time (from info/summary/start-date in the xctrace XML)
+            // rather than to load time. Using DateTime.UtcNow here causes WPA's session timeline to be offset by the elapsed time
+            // between recording and loading, misaligning this trace with other simultaneously-collected sources (e.g. Perfetto).
+            DateTime firstEventWallClockUtc = recordingStartUtc ?? DateTime.UtcNow;
             dataSourceInfo = new DataSourceInfo(firstEventTimestampNanoseconds, lastEventTimestampnanoseconds, firstEventWallClockUtc);
         }
 
-        public void ProcessDataSource(IDataSource dataSource, ref Timestamp? firstEventTimestamp, ref Timestamp? lastEventTimestamp,
+        public void ProcessDataSource(IDataSource dataSource, ref Timestamp? firstEventTimestamp, ref Timestamp? lastEventTimestamp, ref DateTime? recordingStartUtc,
             ISourceDataProcessor<Event, ParsingContext, Type> dataProcessor, IProgress<int> progress, CancellationToken cancellationToken)
         {
             if (!(dataSource is FileDataSource fileDataSource))
@@ -95,8 +100,15 @@ namespace InstrumentsProcessor.Parsing
             
             if (reader.Name == InfoName)
             {
-                // Try to parse the info section first to extract counter names
+                // Try to parse the info section first to extract counter names and the recording wall-clock anchor
                 ParseInfoSection(reader, xmlContext);
+
+                // Aggregate the earliest recording start across data sources, so multi-file loads still produce a coherent anchor.
+                if (xmlContext.RecordingStartUtc.HasValue &&
+                    (!recordingStartUtc.HasValue || xmlContext.RecordingStartUtc.Value < recordingStartUtc.Value))
+                {
+                    recordingStartUtc = xmlContext.RecordingStartUtc.Value;
+                }
             }
             
             if (reader.Name != TraceQueryResultName)
@@ -202,6 +214,17 @@ namespace InstrumentsProcessor.Parsing
             }
 
             xmlContext.SetCounterNames(counterNames);
+
+            // Extract the recording's wall-clock start time (ISO-8601 with offset) from info/summary/start-date.
+            // This anchors WPA's wall-clock for the trace to when it was *recorded*, not when it was *loaded*.
+            XmlNode startDateNode = infoNode.SelectSingleNode(".//summary/start-date");
+            if (startDateNode != null && !string.IsNullOrWhiteSpace(startDateNode.InnerText))
+            {
+                if (DateTimeOffset.TryParse(startDateNode.InnerText.Trim(), out DateTimeOffset startDateOffset))
+                {
+                    xmlContext.SetRecordingStartUtc(startDateOffset.UtcDateTime);
+                }
+            }
         }
     }
 }

--- a/InstrumentsProcessor/Parsing/TraceSourceParser.cs
+++ b/InstrumentsProcessor/Parsing/TraceSourceParser.cs
@@ -76,7 +76,7 @@ namespace InstrumentsProcessor.Parsing
 
             // Anchor the trace's wall-clock to the recording's actual start time (from info/summary/start-date in the xctrace XML)
             // rather than to load time. Using DateTime.UtcNow here causes WPA's session timeline to be offset by the elapsed time
-            // between recording and loading, misaligning this trace with other simultaneously-collected sources (e.g. Perfetto).
+            // between recording and loading, misaligning this trace with other simultaneously-collected sources
             DateTime firstEventWallClockUtc = recordingStartUtc ?? DateTime.UtcNow;
             dataSourceInfo = new DataSourceInfo(firstEventTimestampNanoseconds, lastEventTimestampnanoseconds, firstEventWallClockUtc);
         }

--- a/InstrumentsProcessor/Parsing/XmlParsingContext.cs
+++ b/InstrumentsProcessor/Parsing/XmlParsingContext.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 
 namespace InstrumentsProcessor.Parsing
@@ -21,6 +22,13 @@ namespace InstrumentsProcessor.Parsing
         /// </summary>
         public IReadOnlyList<string> CounterNames { get; private set; }
 
+        /// <summary>
+        /// The wall-clock UTC time at which the trace recording started, parsed from
+        /// info/summary/start-date in the xctrace XML export. Null if not present in
+        /// the input.
+        /// </summary>
+        public DateTime? RecordingStartUtc { get; private set; }
+
         public XmlParsingContext()
         {
             ObjectCache = new ObjectCache();
@@ -34,6 +42,14 @@ namespace InstrumentsProcessor.Parsing
         public void SetCounterNames(IList<string> counterNames)
         {
             CounterNames = new List<string>(counterNames);
+        }
+
+        /// <summary>
+        /// Sets the recording wall-clock start time captured from the info section.
+        /// </summary>
+        public void SetRecordingStartUtc(DateTime recordingStartUtc)
+        {
+            RecordingStartUtc = recordingStartUtc;
         }
     }
 }


### PR DESCRIPTION
<img width="1375" height="467" alt="image" src="https://github.com/user-attachments/assets/3d5cddd3-b23c-4118-bc2b-6b9a7c492a0f" />

Patch bug that caused events of the collected trace to appear in WPA based on UTC time, rather than the internal metadata start time of the xctrace file. This caused situations in the graph above, where even though the original trace was a minute long, loading two traces in one session creates an effective length of several hours


After:
<img width="1399" height="228" alt="image" src="https://github.com/user-attachments/assets/2e7da646-1ad5-4984-a493-ec4214d4702a" />
